### PR TITLE
Fix inaccurate pitches

### DIFF
--- a/src/brseq_commands.c
+++ b/src/brseq_commands.c
@@ -69,14 +69,7 @@ char* decode_notebyte(unsigned char NoteByte, char* NoteNameBuffer) {
 
 
 	char numchar[] = "0123456789";
-	if ((int)floor(NoteDivided) > 0) {
-		notename[2] = numchar[NoteDivided - 1];
-	}
-	else
-	{
-		notename[2] = 'm';
-		notename[3] = '1';
-	}
+	notename[2] = numchar[NoteDivided]; // Replacing if statement
 
 	snprintf(NoteNameBuffer, 6 * sizeof(char), "%s", notename);
 }

--- a/src/rseq_parse.c
+++ b/src/rseq_parse.c
@@ -185,7 +185,7 @@ char* parse_notecmd(FILE* ByteStream, char* CmdPtr, char** Token, int* PrefixCon
 
 	int8_t base = 0;
 
-	if (CmdPtr[0] == 'c' & CmdPtr[0 == 'n']) {
+	if (CmdPtr[0] == 'c' & CmdPtr[1] == 'n') {
 		base = 0x00;
 	}
 	else if (CmdPtr[0] == 'c' & CmdPtr[1] == 's') {
@@ -227,7 +227,7 @@ char* parse_notecmd(FILE* ByteStream, char* CmdPtr, char** Token, int* PrefixCon
 
 	if (CmdPtr[2] != 'm') {
 		int8_t mult = CmdPtr[2] - 48; // subtract char by 48 to get its actual int value instead of ASCII.
-		base = base + ((mult + 1) * 12);
+		base = base + (mult * 12); // Removed +1
 	}
 	fputc(base, ByteStream);
 


### PR DESCRIPTION
I tested this change on 3 Wii channels and saw accurate pitches when decoding and encoding an unmodified brseq/xmlseq. It may need more testing, I don't know if the original code is accurate on certain games or software, where this code may not be.